### PR TITLE
chore(config): remove cache-stages option

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -32,7 +32,6 @@ lb config noauto \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
     --cache-packages false \
-    --cache-stages false \
     --uefi-secure-boot enable \
     --binary-images iso-hybrid \
     --iso-application "$NAME" \


### PR DESCRIPTION
cache-stages option `lb config` is not set with `false` option and complains about this:
````
#-------------------#
# LIVE-BUILD CONFIG #
#-------------------#

[2022-10-01 21:18:34] lb config 
P: Executing auto/config script.
[2022-10-01 21:18:34] lb config noauto --architectures amd64 --mode ubuntu --initramfs none --distribution kinetic --parent-distribution kinetic --archive-areas main restricted universe multiverse --parent-archive-areas main restricted universe multiverse --linux-packages linux-image --linux-flavours generic --bootappend-live boot=casper maybe-ubiquity quiet splash --mirror-bootstrap http://archive.ubuntu.com/ubuntu/ --parent-mirror-bootstrap http://archive.ubuntu.com/ubuntu/ --mirror-chroot-security http://security.ubuntu.com/ubuntu/ --parent-mirror-chroot-security http://security.ubuntu.com/ubuntu/ --mirror-binary-security http://security.ubuntu.com/ubuntu/ --parent-mirror-binary-security http://security.ubuntu.com/ubuntu/ --mirror-binary http://archive.ubuntu.com/ubuntu/ --parent-mirror-binary http://archive.ubuntu.com/ubuntu/ --keyring-packages ubuntu-keyring --apt-options --yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100 --cache-packages false --cache-stages false --uefi-secure-boot enable --binary-images iso-hybrid --iso-application VanillaOS --iso-volume VanillaOS --firmware-binary false --firmware-chroot false --zsync false --security true --updates true --debootstrap-options --exclude=pinephone-tweaks,mobile-tweaks-common,librem5-tweaks,pinetab-tweaks --checksums md5
W: The following is not a valid stage: 'false'
P: Updating config tree for a ubuntu/kinetic/amd64 system
P: Symlinking hooks...
````
which instead is a option to **set stage to cache** according to [manpage](https://manpages.ubuntu.com/manpages/kinetic/en/man1/lb_config.1.html) (slightly outdated but still same for latest lb config).