### PR TITLE
chore: make iso size smaller

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -31,6 +31,7 @@ lb config noauto \
     --parent-mirror-binary "http://archive.ubuntu.com/ubuntu/" \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
+    --apt-recommends false \
     --cache-packages false \
     --cache-stages false \
     --uefi-secure-boot enable \


### PR DESCRIPTION
This PR makes the final iso size smaller by not installing recommends. For me this shrank the size down by about 220mb. In addition because this means less packages are downloaded and installed, this shrinks the build time a little bit.