### PR TITLE
Update kinetic.yml for hindsight before node12 stuffs gets removed

### DIFF
--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -13,7 +13,7 @@ jobs:
       options: --privileged -it
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install needed packages
       run: apt update && apt install debootstrap -y
@@ -21,7 +21,7 @@ jobs:
     - name: Build ISO
       run: ./build.sh etc/terraform.conf
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: VanillaOS 22.10
         path: builds/


### PR DESCRIPTION
this changes the github actions "checkout and upload-artifact" to v3
i have tested this and it builds and no longer warns about node12 being depricated