### PR TITLE
Add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,53 @@
+name: "🐝 Bug Report"
+description: "In case something is broken or doesn't work as expected."
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to help us
+        --------
+        Don't worry, we eat bugs for breakfast.
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: |
+        Tell us, what's the problem? But please keep it brief and on point.
+        Feel free to add screenshots or other necessary attachments.
+      placeholder: |
+        Sometimes I get booted into the C partition I never knew existed.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        What steps would we have to take to reproduce the issue?
+      placeholder: |
+          - Verify that the present partition is A (or B)
+          - Make sure that the future partition is the other one
+          - Reboot
+          - Check the present partition. Sometimes it's C.
+    validations:
+      required: true
+  - type: dropdown
+    id: os-version
+    attributes:
+      label: On what version of Vanilla OS this happens?
+      description: |
+        You can look it up in the Settings app, at the bottom of the About page.
+      options:
+        - "22.10"
+        - "Unreleased"
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      description: |
+        If you feel like it, share some thoughts or additional context.
+      placeholder: |
+        Maybe this is a leftover from my previous OS? IIRC, it used to be installed in the C partition.

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,40 @@
+name: "🌼 Feature Request"
+description: "In case you're missing some feature or have a cool idea."
+labels: ["feature request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to help us
+        --------
+        Don't worry, we love both revolution and evolution.
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: |
+        Explain what feature you have in mind. But please keep the pitch brief and on point.
+        Feel free to add screenshots or other necessary attachments.
+      placeholder: |
+        A system configuration option to always keep it mutable.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: |
+        Why is this feature needed? What problem does it solve?
+      placeholder: > 
+        I love messing with my root partition so much, that I'm getting
+        tired of turning off immutability.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      description: |
+        If you feel like it, share some thoughts or additional context.
+      placeholder: |
+        Maybe it would be better not to have immutability at all? Why do you need it?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: "❓ Ask a Question on Discord"
+    url: https://discord.gg/vanilla-os-1023243680829681704
+    about: Please ask and answer questions there.


### PR DESCRIPTION
Adds forms for bug reports and feature requests, as well as a link to Discord for people with questions.

Expects the repo to have "bug", "feature request" and "triage" tags (currently only the first is available). The "triage" tag is useful to search only for bugs that didn't receive any attention.