### PR TITLE
Stop installer session from auto locking

### DIFF
--- a/etc/config/includes.chroot/etc/xdg/autostart/screen-lock.desktop
+++ b/etc/config/includes.chroot/etc/xdg/autostart/screen-lock.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Deactive lock screen
+Comment=Deactive the gnome lock screen in the live session
+Type=Application
+Icon=nautilus
+Exec=sh -c "gsettings set org.gnome.desktop.screensaver lock-enabled false"

--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -23,5 +23,6 @@ mokutil
 rsync
 sudo
 locales-all
+zstd
 
 vanilla-installer


### PR DESCRIPTION
Disables the auto screen lock feature from gnome to make sure the user doesn't get locked out while installing.
Also installs `zstd` in the chroot environment to make the initramfs compress using zstd and decrease the size of the iso.