### PR TITLE
Fix grub config

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -5,9 +5,9 @@ set -e
 . ./terraform.conf
 
 if [ "$HWE_KERNEL" = "yes" ]; then
-    KERNEL_FLAVORS="generic-hwe-${BASEVERSION}"
+    KERNEL_FLAVORS="amd64-hwe-${BASEVERSION}"
 else
-    KERNEL_FLAVORS="generic"
+    KERNEL_FLAVORS="amd64"
 fi
 
 lb config noauto \


### PR DESCRIPTION
Changes the kernel suffix from `generic` to `amd64` so that grub is able to automatically boot without having to manually change the entries