### PR TITLE
Fixed system shut down moments after boot on some systems.

### DIFF
--- a/etc/config/bootloaders/grub-pc/grub.cfg
+++ b/etc/config/bootloaders/grub-pc/grub.cfg
@@ -15,9 +15,14 @@ menuentry "Try or Install Vanilla OS" {
  linux	KERNEL_LIVE APPEND_LIVE ---
  initrd INITRD_LIVE
 }
-menuentry "Try or Install Vanilla OS (Safe Graphics)" {
+menuentry "Try or Install Vanilla OS (Safe Graphics with nomodeset)" {
  set gfxpayload=keep
  linux	KERNEL_LIVE APPEND_LIVE nomodeset ---
+ initrd INITRD_LIVE
+}
+menuentry "Try or Install Vanilla OS (Safe Graphics with nouveau.modeset=0)" {
+ set gfxpayload=keep
+ linux	KERNEL_LIVE APPEND_LIVE nouveau.modeset=0 ---
  initrd INITRD_LIVE
 }
 grub_platform

--- a/etc/config/bootloaders/isolinux/live.cfg.in
+++ b/etc/config/bootloaders/isolinux/live.cfg.in
@@ -12,11 +12,18 @@ label live-@FLAVOUR@
 	append @APPEND_LIVE@
 
 label live-failsafe
-	menu label Start Vanilla OS (Safe Graphics)
+	menu label Start Vanilla OS (Safe Graphics with nomodeset)
 	set gfxpayload=keep
 	linux @LINUX@
 	initrd @INITRD@
 	append @APPEND_LIVE@ nomodeset
+
+label live-failsafe-alternative
+	menu label Start Vanilla OS (Safe Graphics with nouveau.modeset=0)
+	set gfxpayload=keep
+	linux @LINUX@
+	initrd @INITRD@
+	append @APPEND_LIVE@ nouveau.modeset=0
 
 label hd
 	menu label ^Boot from next volume


### PR DESCRIPTION
As it can be seen here #109, on some specific configurations the Safe Graphics option will not help.
I added an alternative Safe Graphics option, this one using the `nouveau.modeset=0` flag.
This should help in the cases where the `nomodeset` flag doesn't work.

This issue will persist until the Nvidia drivers are installed.
The user after the installation will need to enter the `nouveau.modeset=0` option manually in grub and then install the drivers. The flag will not be needed anymore afterwards.