### PR TITLE
packages: Add firmware packages

### DIFF
--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -10,6 +10,13 @@ cryptsetup
 shim-signed
 shim-helpers-amd64-signed
 
+firmware-linux
+firmware-linux-nonfree
+firmware-linux-free
+firmware-iwlwifi
+firmware-realtek
+firmware-atheros
+
 ca-certificates
 btrfs-progs
 expect


### PR DESCRIPTION
Adds some (partially nonfree) wifi firmware packages to ensure that more hardware is supported in the vanilla os orchid live session.