### PR TITLE
feat/ci: bump actions/checkout to v4, remove workflow dispatch branch

### DIFF
--- a/.github/workflows/orchid.yml
+++ b/.github/workflows/orchid.yml
@@ -2,7 +2,6 @@ name: VanillaOS orchid
 
 on:
   workflow_dispatch:
-    branches: [ orchid ]
 
 jobs:
   build:
@@ -15,7 +14,7 @@ jobs:
       options: --privileged -it
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: De-bloat stock image
       run: |


### PR DESCRIPTION
This commit bumps the version of actions/checkout to v4 which comes with Node 20 along with other performance improvements.

The workflow dispatch parameter doesn't support specifying specific branches. So this commit removes the unnecessary line.