### PR TITLE
fix: adapt the Ubuntu mirror to the new URL

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -27,8 +27,8 @@ lb config noauto \
     --parent-mirror-chroot-security "http://security.ubuntu.com/ubuntu/" \
     --mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
     --parent-mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
-    --mirror-binary "http://archive.ubuntu.com/ubuntu/" \
-    --parent-mirror-binary "http://archive.ubuntu.com/ubuntu/" \
+    --mirror-binary "http://old-releases.ubuntu.com/ubuntu/" \
+    --parent-mirror-binary "http://old-releases.ubuntu.com/ubuntu/" \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
     --apt-recommends false \

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -21,7 +21,7 @@ CHANNEL="all"
 NAME="VanillaOS"
 
 # mirror to fetch packages from
-MIRROR_URL="http://archive.ubuntu.com/ubuntu/"
+MIRROR_URL="http://old-releases.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
 HWE="yes"


### PR DESCRIPTION
Fixes #241 

The ubuntu mirror URL has changed. This MR updates the URL to the new one.

Image was generated locally and tested inside a VM.