### PR TITLE
fix: update binary images to iso-hybrid

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ build () {
   OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
   mkdir -p "$OUTPUT_DIR"
   FNAME="VanillaOS-$VERSION-$CHANNEL.$YYYYMMDD$OUTPUT_SUFFIX"
-  mv $BASE_DIR/tmp/amd64/live-image-amd64.iso "$OUTPUT_DIR/${FNAME}.iso"
+  mv $BASE_DIR/tmp/amd64/live-image-amd64-hybrid.iso "$OUTPUT_DIR/${FNAME}.iso"
 
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to

--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ build () {
   OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
   mkdir -p "$OUTPUT_DIR"
   FNAME="VanillaOS-$VERSION-$CHANNEL.$YYYYMMDD$OUTPUT_SUFFIX"
-  mv $BASE_DIR/tmp/amd64/live-image-amd64-hybrid.iso "$OUTPUT_DIR/${FNAME}.iso"
+  mv $BASE_DIR/tmp/amd64/live-image-amd64.hybrid.iso "$OUTPUT_DIR/${FNAME}.iso"
 
   # cd into output to so {FNAME}.sha256.txt only
   # includes the filename and not the path to

--- a/etc/auto/config
+++ b/etc/auto/config
@@ -36,7 +36,7 @@ lb config noauto \
     --apt-recommends true \
     --cache-packages false \
     --uefi-secure-boot enable \
-    --binary-images iso \
+    --binary-images iso-hybrid \
     --iso-application "$NAME" \
     --iso-volume "$NAME" \
     --firmware-binary false \


### PR DESCRIPTION
This PR updates the `--binary-images` method to use `iso-hybrid` instead of  `iso` for making the ISO bootable in USB sticks (and in Rufus and Etcher). The current `iso` method seems to only support VMs and CDs.

Ref. https://manned.org/lb_config.1

---

Related #244 (Thanks to the suggestion of [hklemp](https://github.com/hklemp) for helping us fix this issue), now installation works fine in Rufus and when pressing continue with Etcher but the "Missing partition layout" will still be shown we can probably ignore it for now, so that someone well versed with Debian install methods can fix it.

In docs for Windows users, I will suggest Ventoy and Rufus alone.