### PR TITLE
feat: add VM packages to live session

### DIFF
--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -97,3 +97,8 @@ plymouth-theme-vanilla
 plymouth-theme-vanilla-bgrt
 plymouth-theme-vanilla-logo
 plymouth-theme-vanilla-text
+
+open-vm-tools
+open-vm-tools-desktop
+virtualbox-guest-utils
+virtualbox-guest-x11


### PR DESCRIPTION
This PR adds the Virtualbox Guest Additions and VMWare's Open VM tools packages to the live session allowing for a proper adaptable resolution for the VMs. Along with advanced features like clipboard sharing, etc.

(These packages are present in the VM image too, but they are prompted for installation in the installer; therefore the installer itself is hard to view at the default resolution without the packages)

I have tested the changes in a VM locally from this test ISO that can be found at <https://github.com/kbdharun/vanilla-os/actions/runs/7473330161>.