### PR TITLE
fix [#295]: disables gnome's lock screen

### DIFF
--- a/etc/config/hooks/live/080-disable-gnome-lock.chroot
+++ b/etc/config/hooks/live/080-disable-gnome-lock.chroot
@@ -2,5 +2,7 @@
 cat > /usr/share/glib-2.0/schemas/90-vanilla-os-lock.gschema.override <<EOF
 [org.gnome.desktop.screensaver]
 lock-enabled=false
+[org.gnome.desktop.lockdown]
+disable-lock-screen=true
 EOF
 glib-compile-schemas /usr/share/glib-2.0/schemas/


### PR DESCRIPTION
This disables the Gnome screen lock in gsettings so users can't accidentally lock themselves out.

Fixes #295