### PR TITLE
fix [#306]: enable hybrid-iso again

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -47,7 +47,6 @@ lb config noauto \
     --checksums md5 \
     --clean \
     --debootstrap-options "--keyring=/usr/share/keyrings/vanilla_keyring.gpg" \
-    --bootloaders "grub-efi"
     "${@}"
 
 


### PR DESCRIPTION
The only side-effect of this is that it makes it bootable on BIOS devices. I think this is not a big deal since we block installing on BIOS in the installer.

Reasoning:

grub-efi is not compatible with a hybrid iso. While the documentation on this is not clear I have figured this because:

iso-hybrid seems to be a hybrid between the iso mode and the hdd mode. The hdd mode seems to create an MBR partition table which seems to be needed for USB boot on some devices. While using grub-* on a hdd image throws and error it doesn't on a hybrid-iso. This makes be think that if you do this for a hybrid-iso it just degrades it to a regular ISO.

Also, if you run file on the iso before you get:
ISO 9660 CD-ROM filesystem data 'Vanilla OS' (bootable)
Building it without grub-efi:
ISO 9660 CD-ROM filesystem data (DOS/MBR boot sector) 'Vanilla OS' (bootable)
The second is the same filetype you get for virtually any other OS ISO.

For anyone curious, the filetype of a hdd image is:
DOS/MBR boot sector; partition 1 : ID=0xb, active, start-CHS (0x4,4,1), end-CHS (0x3ff,254,2), startsector 2048, 3661824 sectors
