### PR TITLE
fix [#309]: adds bgrt_disable karg to stop logos mixing

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -17,7 +17,7 @@ lb config noauto \
     --parent-distribution "$BASECODENAME" \
     --linux-packages "linux-image linux-headers" \
     --linux-flavours "$KERNEL_FLAVORS" \
-    --bootappend-live "boot=live config username=vanilla user-fullname=Vanilla quiet splash" \
+    --bootappend-live "boot=live config username=vanilla user-fullname=Vanilla quiet splash bgrt_disable" \
     \
     --parent-archive-areas "main contrib non-free non-free-firmare" \
     --parent-mirror-bootstrap "$MIRROR_URL" \


### PR DESCRIPTION
The karg was missing, tested on branch https://github.com/taukakao/vanilla-live-iso/actions/runs/8256459393

Fixes #309 