### PR TITLE
fix [#322]: adds time sync package ntpsec

### DIFF
--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -39,6 +39,7 @@ rsync
 sudo
 locales
 zstd
+ntpsec
 
 gdm3
 xorg


### PR DESCRIPTION
There was no time sync package installed so the time was just whatever was set in the UEFI settings. This caused:
Fixes #322 in the installer. 