### PR TITLE
Adds date and run number to artifact name

### DIFF
--- a/.github/workflows/orchid.yml
+++ b/.github/workflows/orchid.yml
@@ -27,7 +27,10 @@ jobs:
     - name: Build ISO
       run: ./build.sh etc/terraform.conf
 
+    - name: Get current date
+      run: echo "::set-env name=CURRENT_DATE::$(date +'%Y-%m-%d')"
+
     - uses: actions/upload-artifact@v4
       with:
-        name: VanillaOS 2
+        name: VanillaOS 2 Beta ${{ env.CURRENT_DATE }} ${{ env.GITHUB_RUN_NUMBER }}
         path: builds/


### PR DESCRIPTION
This allows differentiating the ISO file, makes it easier to keep track of what iso is which especially when you download multiple isos.