### PR TITLE
Fixes orchid.yml's method of seting env vars.

### DIFF
--- a/.github/workflows/orchid.yml
+++ b/.github/workflows/orchid.yml
@@ -28,9 +28,9 @@ jobs:
       run: ./build.sh etc/terraform.conf
 
     - name: Get current date
-      run: echo "::set-env name=CURRENT_DATE::$(date +'%Y-%m-%d')"
+      run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v4
       with:
-        name: VanillaOS 2 Beta ${{ env.CURRENT_DATE }} ${{ env.GITHUB_RUN_NUMBER }}
+        name: VanillaOS 2 Beta ${{ env.CURRENT_DATE }} ${{ github.run_number }}
         path: builds/


### PR DESCRIPTION
In my PR https://github.com/Vanilla-OS/live-iso/pull/325 I didn't test the build to see if it worked ([it did not](https://github.com/Zackaryia/live-iso/actions/runs/8775515107)). I have fixed it and now it works properly.

Example of orchid building properly and the file is renamed properly with the updated orchid.yml with this workflow https://github.com/Zackaryia/live-iso/actions/runs/8776315624