### PR TITLE
fix: typo

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -19,7 +19,7 @@ lb config noauto \
     --linux-flavours "$KERNEL_FLAVORS" \
     --bootappend-live "boot=live config username=vanilla user-fullname=Vanilla quiet splash bgrt_disable" \
     \
-    --parent-archive-areas "main contrib non-free non-free-firmare" \
+    --parent-archive-areas "main contrib non-free non-free-firmware" \
     --parent-mirror-bootstrap "$MIRROR_URL" \
     --parent-mirror-chroot-security "http://deb.debian.org/debian-security" \
     --parent-mirror-binary-security "http://deb.debian.org/debian-security" \


### PR DESCRIPTION
Fixed a typo that prevents firmware installation when using the official Debian source.