### PR TITLE
fix: rename kgx to gnome-console

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -4,32 +4,25 @@ set -e
 
 . ./terraform.conf
 
-if [ "$HWE_KERNEL" = "yes" ]; then
-    KERNEL_FLAVORS="amd64-hwe-${BASEVERSION}"
-else
-    KERNEL_FLAVORS="amd64"
-fi
-
 lb config noauto \
     --architectures "$ARCH" \
     --mode debian \
     --distribution "$BASECODENAME" \
     --parent-distribution "$BASECODENAME" \
     --linux-packages "linux-image linux-headers" \
-    --linux-flavours "$KERNEL_FLAVORS" \
     --bootappend-live "boot=live config username=vanilla user-fullname=Vanilla quiet splash bgrt_disable" \
     \
     --parent-archive-areas "main contrib non-free non-free-firmware" \
     --parent-mirror-bootstrap "$MIRROR_URL" \
     --parent-mirror-chroot-security "http://deb.debian.org/debian-security" \
     --parent-mirror-binary-security "http://deb.debian.org/debian-security" \
-    --parent-mirror-binary "https://repo2.vanillaos.org" \
+    --parent-mirror-binary "$MIRROR_URL" \
     \
     --archive-areas "main contrib non-free non-free-firmware" \
     --mirror-bootstrap "$MIRROR_URL" \
     --mirror-chroot-security "http://deb.debian.org/debian-security" \
     --mirror-binary-security "http://deb.debian.org/debian-security" \
-    --mirror-binary "https://repo2.vanillaos.org" \
+    --mirror-binary "$MIRROR_URL" \
     \
     --keyring-packages debian-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \

--- a/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
+++ b/etc/config/package-lists.vanilla-installer/desktop.list.chroot_live
@@ -49,7 +49,7 @@ gnome-session
 gnome-browser-connector
 gnome-disk-utility
 gnome-control-center
-kgx
+gnome-console
 
 wpasupplicant
 network-manager-gnome

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -22,9 +22,6 @@ NAME="Vanilla OS"
 # mirror to fetch packages from
 MIRROR_URL="https://repo2.vanillaos.org"
 
-# use HWE kernel and packages?
-HWE="yes"
-
 # suffix for generated .iso files
 OUTPUT_SUFFIX=""
 


### PR DESCRIPTION
The package `kgx` has been renamed to `gnome-console` in the Debian repository.